### PR TITLE
chore: expand dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 4
+      default-days: 7


### PR DESCRIPTION
as requested by zizmor linter